### PR TITLE
[Fix] Error: The default option value must be a string

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -22,12 +22,12 @@ const convertConfig = () => {
 
   const cfgOld = {};
   cfgOld.nodeid = localStorage.getItem('nodeid');
-  cfgOld.stakeaddr = stakeaddrLS ? stakeaddrLS.trim() : null;
-  cfgOld.email = emailLS ? emailLS.trim() : null;
-  cfgOld.fqdn = fqdnLS ? fqdnLS.trim() : null;
-  cfgOld.region = regionLS ? regionLS.trim() : null;
+  cfgOld.stakeaddr = stakeaddrLS ? stakeaddrLS.trim() : '';
+  cfgOld.email = emailLS ? emailLS.trim() : '';
+  cfgOld.fqdn = fqdnLS ? fqdnLS.trim() : '';
+  cfgOld.region = regionLS ? regionLS.trim() : '';
   cfgOld.ipv = ipvLS ? ipvLS.trim() : '4';
-  cfgOld.category = catLS ? catLS.trim() : null;
+  cfgOld.category = catLS ? catLS.trim() : '';
   if (cfgOld.stakeaddr) cfgOld.replace = true;
   return { cfgOld };
 };


### PR DESCRIPTION
While setting up a Node, I suffered from a terrible user experience, then I getting stuck by the following error:

````
Configure for secure node
The default option value must be a string
Can not complete setup. The default option value must be a string
````
Originated from this input values at `promptUser(cfg,....`:
````
cfg {
  nodeid: null,
  stakeaddr: null,
  email: null,
  fqdn: null,
  region: null,
  ipv: '4',
  category: null
}
````
